### PR TITLE
Bugfix bar not sticky on mobile & missing width

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -13,7 +13,7 @@ const { title = 'ZachsPage' } = Astro.props;
 <html lang="en">
     <head>
         <meta charset="UTF-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta name="viewport" content="height=device-height, width=device-width, initial-scale=1.0, minimum-scale=1.0, target-density=device-dpi" />
         <link rel="icon" type="image/svg+xml" href="/icons/astro.svg" />
         <meta name="generator" content={Astro.generator} />
         <title>{title}</title>

--- a/src/styles/sidebar.css
+++ b/src/styles/sidebar.css
@@ -99,7 +99,7 @@
     .sidebar {
         position: sticky !important;
         top: 0;
-        width: 100% !important;
+        width: 100vh !important;
         height: auto !important;
         border-bottom: 1px solid var(--color-border);
         border-right: none !important;


### PR DESCRIPTION
Was testing as "mobile" on desktop by shrinking window width - which seemed to work, but on mobile saw:
- Top bar was not `sticky` when scrolling
- Could scroll to the right & a piece of the bar was missing

Should figure out mobile testing, but lets try this first.