### PR TITLE
Add missing top bar width

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -39,6 +39,7 @@ const { title = 'ZachsPage' } = Astro.props;
         background: var(--color-bg-content);
         color: var(--color-text-primary);
         min-height: 100vh;
+        overflow-x: hidden;
     }
 
     .layout {

--- a/src/styles/sidebar.css
+++ b/src/styles/sidebar.css
@@ -99,7 +99,8 @@
     .sidebar {
         position: sticky !important;
         top: 0;
-        width: 100vh !important;
+        left: 0;
+        width: 100%;
         height: auto !important;
         border-bottom: 1px solid var(--color-border);
         border-right: none !important;


### PR DESCRIPTION
Last try - for the top bar, accidentally used "vh" for the width.
Changing back showed a missing segment when scrolling  to the right - change to fill the whole visible space on mobile.