### PR TITLE
Fix blog-post overflow causing bar to be too short

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -28,6 +28,12 @@ const { title = 'ZachsPage' } = Astro.props;
     </body>
 </html>
 <style>
+    :global(*),
+    :global(*::before),
+    :global(*::after) {
+        box-sizing: border-box;
+    }
+
     :global(html) {
         font-family: system-ui, -apple-system, sans-serif;
         scroll-behavior: smooth;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -100,6 +100,29 @@ const musicFiles = [
         </div>
     </section>
 
+    <section id="blog" class="section">
+        <h1>Blog</h1>
+        <p>This section is for my thoughts - the idea was to use Astro to support writing posts 
+            in Markdown for easy publishing.</p>
+        <div class="blog-posts">
+            {renderedPosts.map((post) => (
+                <article id={`blog-${post.id}`} class="blog-post">
+                    <h2>{post.data.title}</h2>
+                    <p class="blog-meta">
+                        Published: {post.data.pubDate.toLocaleDateString('en-US', { 
+                            year: 'numeric', 
+                            month: 'long', 
+                            day: 'numeric' 
+                        })}
+                    </p>
+                    <div class="blog-content">
+                        <post.Content />
+                    </div>
+                </article>
+            ))}
+        </div>
+    </section>
+
     <script>
         const musicPlayer = document.getElementById('musicPlayer') as HTMLAudioElement | null;
         const trackButtons = document.querySelectorAll('.music-track-button');
@@ -125,27 +148,4 @@ const musicFiles = [
             trackItems.forEach(item => item.classList.remove('active'));
         });
     </script>
-
-    <section id="blog" class="section">
-        <h1>Blog</h1>
-        <p>This section is for my thoughts - the idea was to use Astro to support writing posts 
-            in Markdown for easy publishing.</p>
-        <div class="blog-posts">
-            {renderedPosts.map((post) => (
-                <article id={`blog-${post.id}`} class="blog-post">
-                    <h2>{post.data.title}</h2>
-                    <p class="blog-meta">
-                        Published: {post.data.pubDate.toLocaleDateString('en-US', { 
-                            year: 'numeric', 
-                            month: 'long', 
-                            day: 'numeric' 
-                        })}
-                    </p>
-                    <div class="blog-content">
-                        <post.Content />
-                    </div>
-                </article>
-            ))}
-        </div>
-    </section>
 </BaseLayout>

--- a/src/styles/sidebar.css
+++ b/src/styles/sidebar.css
@@ -101,6 +101,7 @@
         top: 0;
         left: 0;
         width: 100%;
+        max-width: 100vw;
         height: auto !important;
         border-bottom: 1px solid var(--color-border);
         border-right: none !important;


### PR DESCRIPTION
Found an issue when clicking one of the blog-post links on the top bar - it scrolled into view, but then the menu bar was too short.  
`box-sizing` ensures padding is included in within the `total width percentage`.